### PR TITLE
Fix broken links by making them absolute

### DIFF
--- a/docs/Frequently-Asked-Questions.md
+++ b/docs/Frequently-Asked-Questions.md
@@ -26,7 +26,7 @@ Re-sync your daemon from scratch(see below question)
 Close any Kryptokrona-related software, then go to `%APPDATA%`, and delete the `Kryptokrona` folder.  
 Reopen Kryptokronad/the GUI wallet and let it re-sync.
 
-Alternatively, check [this guide](guides/wallets/Using-Checkpoints) for instructions on how to use checkpoints for a quicker sync, or try a [remote node](guides/wallets/Using-Remote-Nodes)
+Alternatively, check [this guide](/guides/wallets/Using-Checkpoints) for instructions on how to use checkpoints for a quicker sync, or try a [remote node](/guides/wallets/Using-Remote-Nodes)
 
 ##### Q: When I open Kryptokrona on a Mac, I get an error `Illegal instruction: 4`. How can I fix it?
 
@@ -67,7 +67,7 @@ You can also type `status` in the daemon and press enter to see the current heig
 
 ##### Q: I think I should have more money in my balance than it is showing, what should I do?
 
-Re-sync your daemon from scratch(see [here](#q-how-can-i-re-sync-the-blockchain)), sync [using checkpoints](guides/wallets/Using-Checkpoints) or use a [remote node](guides/wallets/Using-Remote-Nodes)) if you're using the GUI wallet.
+Re-sync your daemon from scratch(see [here](#q-how-can-i-re-sync-the-blockchain)), sync [using checkpoints](/guides/wallets/Using-Checkpoints) or use a [remote node](/guides/wallets/Using-Remote-Nodes)) if you're using the GUI wallet.
 If it still doesn't work, then [update](https://gota.kryptokrona.se)
 
 *  Then, close and reopen kkrwallet and Kryptokronad.
@@ -92,12 +92,12 @@ Your wallet is now being optimized. When it finishes, your transaction should be
 #### Q: How do I send XKR?
 
 
-You can check [this out](guides/wallets/Using-kkrwallet##sending-Kryptokrona-transactions) for steps on how to send XKR to someone.
+You can check [this out](/guides/wallets/Using-kkrwallet##sending-Kryptokrona-transactions) for steps on how to send XKR to someone.
 
 #### Q: How do I send money to exchanges / use payment ID?
 
 
-You can check [this out](guides/wallets/Using-kkrwallet#payment-id) for steps on how to send XKR with the payment ID.
+You can check [this out](/guides/wallets/Using-kkrwallet#payment-id) for steps on how to send XKR with the payment ID.
 
 #### Q: What is mixin?
 
@@ -118,12 +118,12 @@ Currently it takes a couple of hours. This number will increase as more people u
 #### Q: Can I speed up the syncing of the blockchain?
 
 
-You can sync [with checkpoints](guides/wallets/Using-Checkpoints) (only with kkrwallet) or use a [remote node](guides/wallets/Using-Remote-Nodes)
+You can sync [with checkpoints](/guides/wallets/Using-Checkpoints) (only with kkrwallet) or use a [remote node](/guides/wallets/Using-Remote-Nodes)
 
 #### Q: Can I skip the syncing?
 
 
-Yes, you can currently use a remote node with kkrwallet and the desktopwallet. The keys stay on your PC, so it's secure. Check [this guide](guides/wallets/Using-Remote-Nodes) for more information. [Checkpoints](guides/wallets/Using-Checkpoints) are also an option if you're using kkrwallet.
+Yes, you can currently use a remote node with kkrwallet and the desktopwallet. The keys stay on your PC, so it's secure. Check [this guide](/guides/wallets/Using-Remote-Nodes) for more information. [Checkpoints](/guides/wallets/Using-Checkpoints) are also an option if you're using kkrwallet.
 
 #### Q: What does it mean if my balance is locked?
 
@@ -145,7 +145,7 @@ Go into this folder and delete the files in there. Then reboot, and try again.
 
 #### Q: How do I get started mining?
 
-You can check [this guide](guides/mining/Mining)
+You can check [this guide](/guides/mining/Mining)
 
 #### Q: I'm using a Mac, can I still mine?
 
@@ -204,7 +204,7 @@ Yes, in case you get banned, or a pool goes down for some time, you can keep min
 #### Q: Where can I find a list of pools?
 
 
-[Here](guides/mining/Pools) is a list. It also has other nifty stats like the pool's fee, minimum payout and server location.
+[Here](/guides/mining/Pools) is a list. It also has other nifty stats like the pool's fee, minimum payout and server location.
 
 
 #### Q: What pool should I choose?
@@ -222,7 +222,7 @@ There are a few factors to consider when choosing a pool.
 
   This is the amount you need to mine before you get paid. Most pools will list this under the "Payments" tab.
 
-  You can check [this list](guides/mining/Pools) of pools. It specifies each pool's minimum payout as well as server location.
+  You can check [this list](/guides/mining/Pools) of pools. It specifies each pool's minimum payout as well as server location.
 
 #### Q: How many hashes per second is good for my hardware?
 
@@ -275,12 +275,12 @@ Thus to protect against that scenario you could transfer any XKR balance to one 
 #### Q: Can I make a paper wallet?
 
 
-Yes, you can view the guide [here](guides/wallets/Making-a-Paper-Wallet)
+Yes, you can view the guide [here](/guides/wallets/Making-a-Paper-Wallet)
 
 #### Q: I made a paper wallet, how do I use it?
 
 
-You can check out [this guide](guides/wallets/Recovering-your-Wallet) for steps on how to import your paper wallet into a wallet of your choice(choose a wallet and import the keys).
+You can check out [this guide](/guides/wallets/Recovering-your-Wallet) for steps on how to import your paper wallet into a wallet of your choice(choose a wallet and import the keys).
 
 #### Q: Can I view the balance of my wallet online?
 
@@ -299,7 +299,7 @@ Read a great post about the justification for it [here](https://medium.com/@Kryp
 
 There are multiple ways to acquire XKR, for example:
 
-* Mining - see [here](guides/mining/Mining)
+* Mining - see [here](/guides/mining/Mining)
 * Bounties - Bounties for developing XKR software, spreading the word of XKR, and many other things are often posted in the #bounties channel on [Discord][discord_link]. Check the pinned messages for current bounties.
 * Tips - In the Kryptokrona discord we often tip each other, especially if you make spicy memes in the `#memes` channel
 
@@ -319,7 +319,7 @@ None are ready for usage right now, but they are being worked on. Check the deve
 
 #### Q: How do I register my wallet on Discord?
 
-  A: You can check out this guide [here](guides/Using-XKRbot-plus-plus#registering-your-wallet).
+  A: You can check out this guide [here](/guides/Using-XKRbot-plus-plus#registering-your-wallet).
 
 #### Q: Where is the blockchain stored?
 

--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -14,7 +14,7 @@ Below is essentially a checklist of tasks you have to do to get started with Kry
 
 There are multiple types of wallets you can use with Kryptokrona.
 
-To view a list of them, their interface and a brief description, as a well as guides on how to use them, you can check [this guide](guides/wallets/Making-a-Wallet).
+To view a list of them, their interface and a brief description, as a well as guides on how to use them, you can check [this guide](/guides/wallets/Making-a-Wallet).
 
 ## 2. Start Mining Kryptokrona
 
@@ -22,7 +22,7 @@ Mining is essentially the process of using your computer to help verify and secu
 
 If you want to learn about cryptocurrencies, mining is a great place to start!
 
-To view an in-depth guide on how to mine Kryptokrona, you can view [this guide](guides/mining/Mining)
+To view an in-depth guide on how to mine Kryptokrona, you can view [this guide](/guides/mining/Mining)
 
 ## 3. Socialize!
 

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -17,7 +17,7 @@ One of Kryptokrona's main goals is to make things as simple and as accessible as
 | **About Kryptokrona** | **Wallets** | **Mining** | **Contributing** |
 |:----------------------:|:-------------:|:------------:|:------------------:|
 | ![Logo](assets/table_logo.png) | ![Wallets](assets/table_wallet.png) | ![Mining](assets/table_mine.png) | ![Dev](assets/table_dev.png) |
-| [About Kryptokrona](about/About-Kryptokrona) | [Setting up a New Wallet](guides/wallets/Making-a-Wallet) | [Mining Kryptokrona](guides/mining/Mining) | [Contributing to Kryptokrona](about/Contributing) |
+| [About Kryptokrona](/about/About-Kryptokrona) | [Setting up a New Wallet](/guides/wallets/Making-a-Wallet) | [Mining Kryptokrona](/guides/mining/Mining) | [Contributing to Kryptokrona](/about/Contributing) |
 | Learn more about Kryptokrona and the community | A guide on setting up a Kryptokrona wallet to start receiving some turtles! | A step-by-step guide to start mining Kryptokrona | Information on contributing to Kryptokrona |
 
 ## Have Questions or Need Help?

--- a/docs/about/About-Kryptokrona.md
+++ b/docs/about/About-Kryptokrona.md
@@ -29,14 +29,14 @@ Some of the main features of Kryptokrona include:
 
 To learn more about us, check out our other various articles, describing:
 
-- [Our Background and History](Background-and-History)
+- [Our Background and History](/about/Background-and-History)
 
-- [Our Community](Community)
+- [Our Community](/about/Community)
 
-- [How to Contribute](Contributing)
+- [How to Contribute](/about/Contributing)
 
-- [its Technical Data](Technical-Data)
+- [its Technical Data](/about/Technical-Data)
 
-- [Our Timeline](Timeline)
+- [Our Timeline](/about/Timeline)
 
 We recommend you check em out, to get acquainted with Kryptokrona!

--- a/docs/developer/Resources.md
+++ b/docs/developer/Resources.md
@@ -18,11 +18,11 @@ Since Kryptokronan is a fork of turtlecoin, these links will also prove useful.
 
 ## TurtleCoin Core RPC APIs
 
-* [TurtleCoind](api/Daemon-JSON-RPC-API) - Blockchain daemon
+* [TurtleCoind](/developer/api/Daemon-JSON-RPC-API/) - Blockchain daemon
 
 * [wallet-api](https://turtlecoin.github.io/wallet-api-docs/) - Recommended RPC API to use for new projects or to migrate to from existing projects. Swagger based REST interface.
 
-* [turtle-service](api/Legacy-Wallet-RPC-API) - Turtle Service Wallet API. Will eventually be deprecated, suggested to use wallet-api for new projects.
+* [turtle-service](/developer/api/Legacy-Wallet-RPC-API) - Turtle Service Wallet API. Will eventually be deprecated, suggested to use wallet-api for new projects.
 
 ## RPC API Clients
 
@@ -49,5 +49,5 @@ Since Kryptokronan is a fork of turtlecoin, these links will also prove useful.
 
 ## Misc
 
-* [RPC API Error Conditions](api/RPC-API-Error-Conditions) - un-exhaustive list of commons errors which TurtleCoind and turtle-service make, why they happen, and solutions.
+* [RPC API Error Conditions](/developer/api/RPC-API-Error-Conditions) - un-exhaustive list of commons errors which TurtleCoind and turtle-service make, why they happen, and solutions.
 

--- a/docs/developer/Running-Kryptokronad-on-Pi.md
+++ b/docs/developer/Running-Kryptokronad-on-Pi.md
@@ -94,7 +94,7 @@ Now just wait to sync!
 
 ## Speeding Up Synchronization
 
-There's a couple things you can do to speed up the blockchain sync. One is to use checkpoints: follow the directions [here](../guides/wallets/Using-Checkpoints).
+There's a couple things you can do to speed up the blockchain sync. One is to use checkpoints: follow the directions [here](/guides/wallets/Using-Checkpoints).
 
 Alternatively, if you have another computer that already has a synced blockchain, you can copy the data in the .kryptokrona or Appdata/Roaming/kryptokrona folder onto your SSD and enjoy starting with a fully synced chain!
 

--- a/docs/developer/api/Daemon-HTTP-RPC-API.md
+++ b/docs/developer/api/Daemon-HTTP-RPC-API.md
@@ -347,7 +347,7 @@ daemon.feeInfo().then((result) => {
 
 ## License
 
-[![Creative Commons License](../../assets/cc-by-sa.png)](https://creativecommons.org/licenses/by-sa/3.0/)
+[![Creative Commons License](/assets/cc-by-sa.png)](https://creativecommons.org/licenses/by-sa/3.0/)
 
 The content in this document was originally written by the [Bytecoin (BCN) Developers](https://bytecoin.org/). It is licensed under the [CC BY SA 3.0 license](https://creativecommons.org/licenses/by-sa/3.0/). The source material can be found at the [Bytecoin Wiki](https://github.com/bcndev/bytecoin).
 

--- a/docs/guides/mining/CPU-Solo-Mining.md
+++ b/docs/guides/mining/CPU-Solo-Mining.md
@@ -3,7 +3,7 @@ title: Solo-mining Kryptokrona
 ---
 
 Solo-mining Kryptokrona means that you, alone, try to find the next block.  
-**It is extremely hard, and not recommended** - try our [other guides](Mining) if you want a more steady flow of TRTL.  
+**It is extremely hard, and not recommended** - try our [other guides](/guides/mining/Mining) if you want a more steady flow of TRTL.  
 Solo-mining is limited to *only your CPU*.
 
 If you're sure you want to solo mine, let's continue.

--- a/docs/guides/mining/Mining-with-SBC.md
+++ b/docs/guides/mining/Mining-with-SBC.md
@@ -4,7 +4,7 @@ title: Mining with a SBC
 
 The following guide will show you how to compile a CPU miner (XMRig) for SBCs like the Raspberry Pi.
 
-If you're using a RPi3 or RPi3B+, check out [this guide](Optimizing-RPi-Kryptokrona-Mining) for a more optimized setup.
+If you're using a RPi3 or RPi3B+, check out [this guide](/guides/mining/Optimizing-RPi-TurtleCoin-Mining) for a more optimized setup.
 
 What are the benefits of compiling XMRig from scratch?
   - You'll have the most up-to-date version of XMRig
@@ -99,11 +99,11 @@ Your terminal should display the contents of `config.json`.
 
 * In order to mine Kryptokrona, we tell XMRig what algorithm you want to mine. Look out for the `"algo":` setting and change it to `"algo": "cryptonight-pico/trtl",`
 
-* In place of `"url": "donate.v2.xmrig.com:3333",` you'll need to choose a pool to mine towards. Make sure to choose the right port. You can learn more about choosing a pool [here](Pools).
+* In place of `"url": "donate.v2.xmrig.com:3333",` you'll need to choose a pool to mine towards. Make sure to choose the right port. You can learn more about choosing a pool [here](/guides/mining/Pools).
 
 * Instead of `"user": "YOUR_WALLET_ADDRESS",` simply paste your Kryptokrona wallet address.
 
-  If you don't have one yet, you can find out how to create a wallet [here](../wallets/Making-a-Wallet).
+  If you don't have one yet, you can find out how to create a wallet [here](/guides/wallets/Making-a-Wallet).
 
 When you're done with that, press: 
 

--- a/docs/guides/mining/Mining.md
+++ b/docs/guides/mining/Mining.md
@@ -25,20 +25,20 @@ There are currently a few different ways in which you can start mining Kryptokro
 
 XMRig comes as a CPU and GPU miner separately and run two separate instances in your computer. One will use your CPU and the other one will use your GPU.
 
-Please follow [this guide](XMRIG-Guide) to start mining Kryptokrona with XMRig.
+Please follow [this guide](/guides/mining/XMRIG-Guide) to start mining Kryptokrona with XMRig.
 
 ### Solo Mining
 
-Solo Mining is where you, alone, try to solve a block. It is extremely difficult and not recommended. If you'd like to give it a hand regardless see [this guide](CPU-Solo-Mining)
+Solo Mining is where you, alone, try to solve a block. It is extremely difficult and not recommended. If you'd like to give it a hand regardless see [this guide](/guides/mining/CPU-Solo-Mining)
 
 ## SBC/Raspberry Pi Mining
 
-Please follow [this guide](Mining-with-SBC) to mine with a SBC/Rasperry Pi.
+Please follow [this guide](/guides/mining/Mining-with-SBC) to mine with a SBC/Rasperry Pi.
 
 
 ## Pools
 
-You may view more info on mining pools [here](Pools).
+You may view more info on mining pools [here](/guides/mining/Pools).
 
 ## Have Questions or Need Help?
 

--- a/docs/guides/mining/Optimizing-RPi-TurtleCoin-Mining.md
+++ b/docs/guides/mining/Optimizing-RPi-TurtleCoin-Mining.md
@@ -4,7 +4,7 @@ title: Optimizing Mining on a RPi
 
 ### Notes
 
-Looking for a more general SBC setup guide? Check out [this guide](Mining-with-SBC).
+Looking for a more general SBC setup guide? Check out [this guide](/guides/mining/Mining-with-SBC).
 
 ## Overview
 

--- a/docs/guides/mining/Pools.md
+++ b/docs/guides/mining/Pools.md
@@ -2,7 +2,7 @@
 title: Mining Pools
 ---
 
-Unless you want to [solo mine](CPU-Solo-Mining), which is unfeasible for many people, you will need a pool to mine towards. Make sure to choose the one closest to you!
+Unless you want to [solo mine](/guides/mining/CPU-Solo-Mining), which is unfeasible for many people, you will need a pool to mine towards. Make sure to choose the one closest to you!
 
 To view a list of pools, check out [the explorer](https://explorer.kryptokrona.se/pools.html)
 

--- a/docs/guides/mining/XMRIG-Guide.md
+++ b/docs/guides/mining/XMRIG-Guide.md
@@ -43,9 +43,9 @@ Needs to be compiled. Instructions [here](https://github.com/xmrig/xmrig/wiki/OS
 * `"user: "[wallet address]"`
 
 - Instead of `[wallet address]`, simply paste your Kryptokrona wallet's address. Make sure to keep the `"`!
-  - If you don't have one yet, you can find out how to create a wallet [here](../wallets/Making-a-Wallet)
+  - If you don't have one yet, you can find out how to create a wallet [here](/guides/wallets/Making-a-Wallet)
 
-- In place of `[pool address]`, you'll need to choose a pool to mine towards. You can learn more about them [here](Pools). Make sure to keep the `"`s!  
+- In place of `[pool address]`, you'll need to choose a pool to mine towards. You can learn more about them [here](/guides/mining/Pools). Make sure to keep the `"`s!  
 
 1.  Save the file and:
   * start `xmrig.exe` if you're mining with your CPU,

--- a/docs/guides/wallets/Making-a-Paper-Wallet.md
+++ b/docs/guides/wallets/Making-a-Paper-Wallet.md
@@ -6,7 +6,7 @@ The main purpose of a paper wallet is to quickly create a wallet to start receiv
 
 **You will not be able to spend or send your funds to other people until you set up a CLI, GUI or Web Wallet.**
 
-You can view a guide on how to make a wallet [here](Making-a-Wallet)
+You can view a guide on how to make a wallet [here](/guides/wallets/Making-a-Wallet)
 
 There are two options for a paper wallet.
 

--- a/docs/guides/wallets/Making-a-Wallet.md
+++ b/docs/guides/wallets/Making-a-Wallet.md
@@ -14,17 +14,17 @@ The main purpose of a paper wallet is to quickly create a wallet to start receiv
 
 **You will not be able to spend or send your funds to other people until you set up a CLI, GUI or Web Wallet.**
 
-To view a guide on how to make a paper wallet, you can go [here](Making-a-paper-wallet).
+To view a guide on how to make a paper wallet, you can go [here](/guides/wallets/Making-a-paper-wallet).
 
 ## Kkrwallet (CLI Wallet)
 
 The CLI Wallet, called kkrwallet, is a multi-platform program (Win/Linux/Mac) that requires you to enter commands for it to work and you cannot use your mouse. However, it is currently the most stable and gets the newest updates first.
 
-If you would like to use kkrwallet, you can check out [this guide](Using-kkrwallet).
+If you would like to use kkrwallet, you can check out [this guide](/guides/wallets/Using-kkrwallet).
 
 ## Kryptokrona Wallet (GUI Wallet)
 
 Kryptokronan also has a GUI wallet, It's open sourced and available on every major OS. You can download it [here](https://kryptokrona.se/en/kryptokrona-wallet-2/), or view the source code [here](https://github.com/kryptokrona/kryptokrona-wallet)
 
-If you would like to use it, you can check out [this guide](Using-Proton-Wallet)
+If you would like to use it, you can check out [this guide](/guides/wallets/Using-Remote-Nodes/#proton-wallet)
 

--- a/docs/guides/wallets/Recovering-your-Wallet.md
+++ b/docs/guides/wallets/Recovering-your-Wallet.md
@@ -6,8 +6,8 @@ In case you have lost your wallet, but still have either your private spend and 
 
 ## kkrwallet
 
-View [this guide](Using-kkrwallet#restoring-your-wallet) for steps on recovering your wallet with your private spend and view keys, or your 25 word mnemonic seed with kkrwallet
+View [this guide](/guides/wallets/Using-kkrwallet#restoring-your-wallet) for steps on recovering your wallet with your private spend and view keys, or your 25 word mnemonic seed with kkrwallet
 
 ## Kryptokrona Wallet
 
-View [this guide](Using-Kryptokrona-wallet#restoring-a-wallet-from-seed-or-keys) for steps on recovering your wallet with your private spend and view keys, or your 25 word mnemonic seed with Proton Wallet.
+View [this guide](/guides/wallets/Using-Kryptokrona-Wallet#restoring-a-wallet-from-seed-or-keys) for steps on recovering your wallet with your private spend and view keys, or your 25 word mnemonic seed with Proton Wallet.

--- a/docs/guides/wallets/Using-Kryptokrona-Wallet.md
+++ b/docs/guides/wallets/Using-Kryptokrona-Wallet.md
@@ -4,13 +4,13 @@ title: Using Kryptokrona Wallet
 
 Kryptokrona Wallet is a cross-platform GUI wallet that is written using JavaScript and the Electron framework together with React. The UI was inspired by Electrum's QT client. It's simple, easy to use, and utilizes the latest in backend technologies from the kryptokrona™ development team.
 
-<!-- ![Screenshot of Kryptokrona Wallet running](../../assets/screenshot-proton-wallet.png) -->
+<!-- ![Screenshot of Kryptokrona Wallet running](/assets/screenshot-proton-wallet.png) -->
 
 ## Downloading
 
 The installers can be found [here](https://github.com/kryptokrona/kryptokrona-desktop-wallet/releases/latest). Download the appropriate file for your computer. The files are located under the "Assets" tag, just scroll down to the bottom of the latest release.
 
-<!-- ![Location of release files](../../assets/proton-releases-location.png) -->
+<!-- ![Location of release files](/assets/proton-releases-location.png) -->
 
 Just in case you're not sure what to download, here is a list of the files and what operating systems they go to:
 
@@ -26,7 +26,7 @@ Just in case you're not sure what to download, here is a list of the files and w
 
 After downloading the .exe file, navigate to the folder you downloaded it to and double-click it. You'll be greeted with a scary-looking screen from Windows saying it protected your PC by blocking an uncregonized app:
 
-<!-- ![Screenshot of windows protected your PC message](../../assets/proton-windows-error.png) -->
+<!-- ![Screenshot of windows protected your PC message](/assets/proton-windows-error.png) -->
 
 Click **more info** and then click **run anyway.** After this, you'll be able to install the program normally.
 
@@ -40,21 +40,21 @@ SEKReX2avthCKT4YUUKV3jgZ1Hderk9XbRciqp8vHVPoDSb9nA1dCV86Jia3TkD4jWgfxeh1AEYV3DKE
 
 Once you've made it past the nag screen and onto the installer screen, select your choices the installer asks for and install the program. Once it is completed installing, you can launch it by double-clicking the icon on your desktop or navigating to Kryptokrona Wallet in the start menu and clicking it. The first step of the installer screen is pictured below:
 
-<!-- ![Screenshot of the installer utility for windows](../../assets/proton-windows-installer.png) -->
+<!-- ![Screenshot of the installer utility for windows](/assets/proton-windows-installer.png) -->
 
 ### Installing on Mac
 
 Double click the .dmg file, and the installer prompt will appear. Simply drag the Kryptokrona Wallet icon on the left into the "Applications" directory on the right in order to install it.
 
-<!-- ![Screenshot of mac installer](../../assets/proton-mac-installer.png) -->
+<!-- ![Screenshot of mac installer](/assets/proton-mac-installer.png) -->
 
 **Important: Try to run the program at this point.** (You can do so by clicking on the icon in the dock.) Unfortunately, you'll get a nasty error message from MacOS, which we'll take care of in the next step.
 
-<!-- ![Screenshot of mac error message for untrusted developer](../../assets/proton-mac-error.png) -->
+<!-- ![Screenshot of mac error message for untrusted developer](/assets/proton-mac-error.png) -->
 
 In order to run the program, navigate to **System Preferences**, and click **Security & Privacy**. You'll see a message near the bottom that Kryptokrona was blocked because it is not from an identified developer, with a button next to it that says **Open Anyway**. Click that button.
 
-<!-- ![Mac security preferences location of open anyway button](../../assets/proton-mac-open-anyway.png) -->
+<!-- ![Mac security preferences location of open anyway button](/assets/proton-mac-open-anyway.png) -->
 
 After this, you can run the program as normal by double clicking on the icon on the dock. (Unfortunately, you will have to do this every time the application updates as well)
 
@@ -77,7 +77,7 @@ After downloading the AppImage file, you'll need to mark it as an executable so 
 3. Click on `Permissions`.
 4. Tick the box next to `Allow executing file as program`.
 
-<!-- ![Location of tickbox to enable executing file as a program](../../assets/proton-linux-appimage.png) -->
+<!-- ![Location of tickbox to enable executing file as a program](/assets/proton-linux-appimage.png) -->
 
 #### Using the Command Line
 
@@ -92,7 +92,7 @@ After completing one of the two above steps, you can launch the wallet simply by
 
 Upon opening Kryptokrona Wallet for the first time, you will see this splash screen:
 
-<!-- ![proton splash screen](../../assets/proton-splashscreen.png) -->
+<!-- ![proton splash screen](/assets/proton-splashscreen.png) -->
 
 You have the following options, and clicking each button will take you to the corresponding utility in the wallet. Click on the link to jump to right section of this guide depending on what you'd like to do.
 
@@ -107,7 +107,7 @@ Once you've created a wallet through one of these options, it will automatically
 1. Click on `File` in the top left and then `New` (or press `Ctrl + N` on your keyboard)
 2. Choose a directory and a name to save the wallet (no need for an extension, but you can use one if you'd like). You'll see the below message when it is successfully created.
 
-<!-- ![proton wallet pass notification](../../assets/proton-wallet-pass-notice.png) -->
+<!-- ![proton wallet pass notification](/assets/proton-wallet-pass-notice.png) -->
 
 Once your wallet is created, you can navigate to Wallet > Password in the top menu to set a password if desired. You're now all set to start receiving and sending funds with kryptokrona™ and Kryptokrona Wallet!
 
@@ -133,13 +133,13 @@ You'll be presented with a dialog box asking if you'd like to restore from priva
 
 If you don't know what height to start scanning from, that's OK, just leave this field blank and it will scan from 0.
 
-<!-- ![proton restore keys menu](../../assets/proton-restore-keys-menu.png) -->
+<!-- ![proton restore keys menu](/assets/proton-restore-keys-menu.png) -->
 
 1. Click `Import`.
 2. Choose a directory and a name to save the wallet.
 3. If the wallet was restored succesfully, you will be given a confirmation message:
 
-<!-- ![proton restore success](../../assets/proton-restore-success.png) -->
+<!-- ![proton restore success](/assets/proton-restore-success.png) -->
 
 After this, your wallet will automatically open. Add a password if desired by navigating to Wallet > Password in the top menu. You've now finished importing your wallet into Kryptokrona Wallet and are ready to start using it!
 
@@ -150,13 +150,13 @@ After this, your wallet will automatically open. Add a password if desired by na
 
 If you don't know what height to start scanning from, that's OK, just leave this field blank and it will scan from 0.
 
-<!-- ![proton restore seed menu](../../assets/proton-restore-seed-menu.png) -->
+<!-- ![proton restore seed menu](/assets/proton-restore-seed-menu.png) -->
 
 3. Click `Import`.
 4. Choose a directory and a name to save the wallet
 5. If the wallet was restored succesfully, you will be given a confirmation message:
 
-<!-- ![proton restore success](../../assets/proton-restore-success.png) -->
+<!-- ![proton restore success](/assets/proton-restore-success.png) -->
 
 After this, your wallet will automatically open. Add a password if desired by navigating to Wallet > Password in the top menu. You've now finished importing your wallet into Kryptokrona Wallet and are ready to start using it!
 
@@ -173,20 +173,20 @@ Click on `Wallet` in the top left, and then `Backup`. A screen will appear with 
 
 Copy the text and store it **safely and securely**. One good way is to print them out on paper and keep them somewhere safe.
 
-<!-- ![proton keys](../../assets/proton-keys.png) -->
+<!-- ![proton keys](/assets/proton-keys.png) -->
 
 ### Viewing Wallet Address
 
 - Click on Receive in the top left
 - Your kryptokrona™ wallet address and a QR code will be displayed. Click on the `Copy to Clipboard` button to copy your address directly.
 
-<!-- ![proton address](../../assets/proton-address.png) -->
+<!-- ![proton address](/assets/proton-address.png) -->
 
 ### Viewing Wallet Balance
 
 You can see your wallet balance at the bottom of the screen in the main `Wallet` screen. You can also see a historical balance, similar to how a checkbook or bank account functions, on the right-most column of the transaction table.
 
-<!-- ![proton balance](../../assets/proton-balance.png) -->
+<!-- ![proton balance](/assets/proton-balance.png) -->
 
 ### Sending Transactions
 
@@ -197,16 +197,16 @@ To send kryptokrona™:
 3. Type the amount of XKR you want to send (like `100`). Note that the total amount with fees will be displayed for you automatically on the right side, including a network minumum fee of 0.1 XKR and a node fee if you're connected to a node with a fee.
 4. Enter the payment ID if the recipient has provided one, or if you require one for your own purposes. Check the [payment ID section](#payment-ids-and-how-to-use-them) if you're not sure how/when to use it.
 
-<!-- ![proton send screen](../../assets/proton-send-screen.png) -->
+<!-- ![proton send screen](/assets/proton-send-screen.png) -->
 
 5. Click on `Send`
 6. Confirm details and click `OK` if you're alright with the transaction. Otherwise, click `Cancel` or press `esc` on your keyboard.
 
-<!-- ![proton confirm send](../../assets/proton-send-confirmation.png) -->
+<!-- ![proton confirm send](/assets/proton-send-confirmation.png) -->
 
 - If the transaction is successful, you will be given a confirmation message:
 
-<!-- ![proton send success](../../assets/proton-send-success.png) -->
+<!-- ![proton send success](/assets/proton-send-success.png) -->
 
 ### Payment IDs and How to Use Them
 
@@ -238,28 +238,28 @@ As much effort as possible is made to ensure Kryptokrona is free of bugs and wor
 
 1. Start Kryptokrona Wallet as you normally do. You should be greeted by the login screen.
 
-<!-- ![proton login screen](../../assets/proton-login.png) -->
+<!-- ![proton login screen](/assets/proton-login.png) -->
 
 2. Log in to the wallet. Your wallet transaction history should display. Press the settings cog button on the top right.
 
-<!-- ![proton wallet settings cog location](../../assets/proton-settings-cog-location.png) -->
+<!-- ![proton wallet settings cog location](/assets/proton-settings-cog-location.png) -->
 
 3. The settings page should be displayed. On the left menu, click the "Wallet" tab to go to the wallet settings.
 
-<!-- ![proton wallet settings button location](../../assets/proton-wallet-settings-location.png) -->
+<!-- ![proton wallet settings button location](/assets/proton-wallet-settings-location.png) -->
 
 4. Click the drop down labelled "WalletBackend Log Level". Select DEBUG as the option. This is usually sufficient, the developers may ask you to repeat this process with TRACE selected.
 
-<!-- ![proton wallet log level drop down](../../assets/proton-debug-logging-settings.png) -->
+<!-- ![proton wallet log level drop down](/assets/proton-debug-logging-settings.png) -->
 
 5. Click the "Show Console" button, located directly under the log level dropdown. A new window will open up. Click "Console" on the top of that new window.
 
-<!-- ![proton wallet dev console](../../assets/proton-wallet-dev-console.png) -->
+<!-- ![proton wallet dev console](/assets/proton-wallet-dev-console.png) -->
 
 6. IMPORTANT: Go back to the wallet. Reproduce whatever bug you're trying to report. If it's a transaction bug, make a transaction, if it's a syncing bug, allow it to attempt to sync for a period of time, etc.
 
 7. Back in the console window, right click the text you should see scrolling by and select "Save as." Save the log file somewhere on your computer that you know how to access (i.e., your desktop). Drag and drop the log file into the GitHub text box or Discord with your bug report.
 
-<!-- ![proton save log file](../../assets/proton-save-log-file.png) -->
+<!-- ![proton save log file](/assets/proton-save-log-file.png) -->
 
 That's it! You've successfully saved a log file and helped your developer solve your problem. The developer will review the log file and attempt to make any necessary fixes.

--- a/docs/guides/wallets/Using-Remote-Nodes.md
+++ b/docs/guides/wallets/Using-Remote-Nodes.md
@@ -17,7 +17,7 @@ In case you don't want to download the blockchain and verify it everytime, you c
 
 - You may also click "Find node..." which will select a random node
 
-![proton remote node](../../assets/kryptokrona-remote-nodes.png)
+![proton remote node](/assets/kryptokrona-remote-nodes.png)
 
 ## kkrwallet
 

--- a/docs/guides/wallets/Using-kkrwallet.md
+++ b/docs/guides/wallets/Using-kkrwallet.md
@@ -36,11 +36,11 @@ unzip kryptokrona-...-linux.zip
 
 Running `kryptokrona` will start the *kryptokrona* network daemon, which will connect to the network and begin downloading and verifying the kryptokrona blockchain.  
 
-Because the blockchain is constantly growing, the file size always increases (the blockchain is currently over 35 GB), and *kryptokrona must verify every block*, which is both CPU and disk intensive. An SSD with at least this much free disk space is recommended, unless you plan to use [remote nodes](Using-Remote-Nodes). 
+Because the blockchain is constantly growing, the file size always increases (the blockchain is currently over 35 GB), and *kryptokrona must verify every block*, which is both CPU and disk intensive. An SSD with at least this much free disk space is recommended, unless you plan to use [remote nodes](/guides/wallets/Using-Remote-Nodes). 
 
 ### Using Checkpoints
 
-In **versions 0.4.3+** you can sync a fresh chain from block 0 much quicker by using checkpoints. Follow [this guide](Using-Checkpoints) to learn more.
+In **versions 0.4.3+** you can sync a fresh chain from block 0 much quicker by using checkpoints. Follow [this guide](/guides/wallets/Using-Checkpoints) to learn more.
 
 ### Windows
 


### PR DESCRIPTION
Almost all links in the docs are broken, which appears to stem from an improper implementation of relative links. 
Instead of directing the user to a neighboring page, the routing tries to navigate to a non-existant child page. 

This is one proposed fix; making the relevant links absolute instead of relative. I have also set up a corresponding fix of the relative navigation: #8.

Either one is fine, I think, with separate pros and cons. I'll leave it to the maintainers to decide, or to go with another route entirely.